### PR TITLE
support /l/, /x/, and subcomponent paths

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -51,7 +51,7 @@ main = do
             case stripPrefix dir file of
               Nothing -> Left file
               Just x -> case splitDirectories x of
-                ("/": "build": hostOs: ghcVersion: packageName: "build": modulePath) -> Right GhcFile{..}
+                ("/" : "build" : hostOs : ghcVersion : packageName : componentType : subComponent : "build" : modulePath) -> Right GhcFile{..}
                 _ -> Left file
 
   unless (Prelude.null files_failed) $ do

--- a/src/GhcFile.hs
+++ b/src/GhcFile.hs
@@ -18,6 +18,8 @@ data GhcFile = GhcFile
   { hostOs :: String -- ^ Host
   , ghcVersion :: String
   , packageName :: String
+  , componentType :: String
+  , subComponent :: String
   , modulePath :: [String]
   }
   deriving (Show, Generic)
@@ -29,7 +31,7 @@ data GhcFile = GhcFile
 -- It looks terrible, seems a wrong abstraction is here.
 rebuildFilePath :: FilePath -> GhcFile -> FilePath
 rebuildFilePath base GhcFile{..} =
-  base </> "build" </> hostOs </> ghcVersion </> packageName </> "build" </> joinPath modulePath
+  base </> "build" </> hostOs </> ghcVersion </> packageName </> componentType </> subComponent </> "build" </> joinPath modulePath
 
 -- | Convert 'GhcFile' into plain filename that we use in our report storage.
 rebuildPlainPath :: GhcFile -> FilePath


### PR DESCRIPTION
I found that my project had paths more like this

```
dist-newstyle/build/x86_64-osx/ghc-8.8.3/[packageName]/l/
dist-newstyle/build/x86_64-osx/ghc-8.8.3/[packageName]/x/
```

`/l/` for libraries, `/x/` for executables.

Underneath each are the subcomponents (sub-library components described here: https://www.haskell.org/cabal/users-guide/developing-packages.html#sublibs), then finally the `build` dir and the `modulePath`

```
dist-newstyle/build/x86_64-osx/ghc-8.8.3/[packageName]/[componentType]/[subProject]/build/
```

After this, the reports work perfectly!

<img width="1311" alt="Screen Shot 2020-03-11 at 3 25 44 pm" src="https://user-images.githubusercontent.com/17399/76382373-a14e2800-63ac-11ea-8ca7-350e25331063.png">
