### PR TITLE
Make path parsing slightly more robust

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -53,7 +53,13 @@ main = do
               Just x -> case x of
                 ("build" : hostOs : ghcVersion : packageName : componentType : subComponent : "build" : modulePath) ->
                   Right GhcFile{..}
+                ("build" : hostOs : ghcVersion : packageName : componentType : subComponent : "noopt" : "build" : modulePath) ->
+                  Right GhcFile{..}
                 ("build" : hostOs : ghcVersion : packageName : "build" : modulePath) ->
+                  let componentType = ""
+                      subComponent = ""
+                  in Right GhcFile{..}
+                ("build" : hostOs : ghcVersion : packageName : "noopt" : "build" : modulePath) ->
                   let componentType = ""
                       subComponent = ""
                   in Right GhcFile{..}

--- a/Main.hs
+++ b/Main.hs
@@ -48,16 +48,16 @@ main = do
   let ( files_failed,
         files_parsed)
         = partitionEithers $ files <&> \srcFilePath ->
-            case stripPrefix dir srcFilePath of
+            case stripPrefix (splitDirectories dir) (splitDirectories srcFilePath) of
               Nothing -> Left srcFilePath
-              Just x -> case splitDirectories x of
-                ("/" : "build" : hostOs : ghcVersion : packageName : componentType : subComponent : "build" : modulePath) ->
+              Just x -> case x of
+                ("build" : hostOs : ghcVersion : packageName : componentType : subComponent : "build" : modulePath) ->
                   Right GhcFile{..}
-                ("/" : "build" : hostOs : ghcVersion : packageName : "build" : modulePath) ->
+                ("build" : hostOs : ghcVersion : packageName : "build" : modulePath) ->
                   let componentType = ""
                       subComponent = ""
                   in Right GhcFile{..}
-                ("/": "dist": hostOs : _cabalVersion : "build": modulePath) ->
+                ("dist": hostOs : _cabalVersion : "build": modulePath) ->
                   -- FIXME: should be retrieved from stack somehow
                   let ghcVersion = "<GHC version>"
                       packageName = "<Package name>"
@@ -67,10 +67,10 @@ main = do
                 _ -> Left srcFilePath
 
   unless (Prelude.null files_failed) $ do
-    Prelude.putStrLn "Warning, some files are failed to be parsed"
+    Prelude.putStrLn "Warning, some files failed to be parsed"
     Prelude.print files_failed
 
-  
+
   -- Output all files in json form for later analysis.
   results <- for files_parsed $ \f -> do
     steps <- fmap parsePhases $ T.readFile (rebuildFilePath f)
@@ -88,7 +88,7 @@ main = do
   -- FIXME: put this file back later
   -- encodeFile (output </> "stats_by_package" <.> "json") stats_by_package
   for_ (Map.toList stats_by_package) $ \(package, stat) -> do
-    let headers = Set.toList $ Set.fromList 
+    let headers = Set.toList $ Set.fromList
            [ phaseName
            | (_, steps) <- Map.toList stat
            , Phase{..} <- steps
@@ -98,7 +98,7 @@ main = do
                  , Prelude.map (\n -> Map.lookup n by_phase) headers)
                | (GhcFile{..}, steps) <- Map.toList stat
                , let total = Prelude.sum [phaseTime | Phase{..} <- steps]
-               , let by_phase =  Map.fromListWith (+) 
+               , let by_phase =  Map.fromListWith (+)
                                     [ (phaseName, phaseTime)
                                     | Phase{..} <- steps
                                     ]
@@ -107,7 +107,7 @@ main = do
     mkHtmlFile ("./tmp/" <> package <> ".html")
       $ Report.packageTable package headers rows
     let bs = Csv.encodeHeader (V.fromList ("module": "total": Prelude.map T.encodeUtf8 headers))
-             <> mconcat (Prelude.map Csv.encodeRecord 
+             <> mconcat (Prelude.map Csv.encodeRecord
                [ Prelude.map T.encodeUtf8 $ T.pack (joinPath modulePath):(showt total):Prelude.map showt cols
                | (GhcFile{..}, total, cols) <- rows
                ])
@@ -135,6 +135,6 @@ findDumpTimings input = do
 mkHtmlFile :: FilePath -> Markup -> IO ()
 mkHtmlFile fn markup = do
   B.writeFile fn "" -- TODO: properly cleanup the file
-  renderMarkupToByteStringIO 
+  renderMarkupToByteStringIO
     (B.appendFile fn) -- TODO: keep handle opened instead of reopening each time.
     markup


### PR DESCRIPTION
The code that was recognizing the various paths stripped off the prefix provided by the user, and then looked at the remainder, recognizing paths such as `/build/...`. However, if the path provided by the user _terminated_ in a forward slash (which would happen quite naturally if using bash completion), it would fail to recognize all files, since they would no longer start with a forward slash `/build/..` but would instead look like `build/..`. We now _first_ split into directories and _then_ use `stripPrefix`, so that now `ghc-timings dist-newstyle/` and `ghc-timings dist-newstyle` both work.

Not a big deal, but it took me a while to figure out why `ghc-timings` "suddenly" failed to recognize anything :)